### PR TITLE
DARK:Enhance Value Checking Mechanism in Filter Processing

### DIFF
--- a/Tests/QueryFilterTest.php
+++ b/Tests/QueryFilterTest.php
@@ -29,3 +29,12 @@ test('it can be casted to array', function () {
 
     expect($queryFilter->toArray())->toEqual(['field' => 'myfield', 'operator' => '=', 'value' => 'myvalue']);
 });
+
+test('does 0 as filters[field] value supported', function () {
+    $queryFilter = new QueryFilter('field', QueryFilter::OPERATOR_EQ, 0);
+
+    expect($queryFilter->getField())->toEqual('field');
+    expect($queryFilter->getValue())->toBeInt()->toEqual(0);
+    expect($queryFilter->getValue())->not()->toBeNull();
+    expect($queryFilter->getOperator())->toEqual('=');
+});

--- a/Tests/QueryFilterTest.php
+++ b/Tests/QueryFilterTest.php
@@ -33,8 +33,6 @@ test('it can be casted to array', function () {
 test('does 0 as filters[field] value supported', function () {
     $queryFilter = new QueryFilter('field', QueryFilter::OPERATOR_EQ, 0);
 
-    expect($queryFilter->getField())->toEqual('field');
     expect($queryFilter->getValue())->toBeInt()->toEqual(0);
     expect($queryFilter->getValue())->not()->toBeNull();
-    expect($queryFilter->getOperator())->toEqual('=');
 });

--- a/src/QueryOptionFactory.php
+++ b/src/QueryOptionFactory.php
@@ -28,7 +28,7 @@ class QueryOptionFactory
         $queryFilters = new QueryFilterCollection();
 
         foreach ((array)Arr::get($attributes, 'filters', []) as $filter) {
-            if (!Arr::has($filter, ['field', 'value']) || empty($filter['field']) || empty($filter['value'])) {
+            if (!Arr::has($filter, ['field', 'value']) || empty($filter['field']) || !isset($filter['value'])) {
                 continue;
             }
 


### PR DESCRIPTION
**Description**:
 This PR addresses two main issues in our filter processing:

-   Fixes the handling of zero values (0, 0.0, "0") mistakenly considered empty by empty(). This is crucial for correctly 
   processing enum integer values, especially when 0 is a valid enum.
-   Refines the use of isset() to include $filters['value'] = null in processing, acknowledging that filtering by null can be 
   intentional and should be supported.

**Outcome**:

1. Zero values are now correctly processed, ensuring accurate filtering.
2. null values are intentionally included, offering greater flexibility in filter criteria.

**QA**
Run the following : 
` ./vendor/bin/pest Tests/QueryFilterTest.php`
 - `does 0 as filters[field] value supported`  context function check if 0 supported, before this change when you have value =0 then $queryFilter->getField() = null 

 